### PR TITLE
Automatically scale map based on "width" prop

### DIFF
--- a/examples/example_us_students.jsx
+++ b/examples/example_us_students.jsx
@@ -273,6 +273,7 @@ class ExampleApp extends React.Component {
           IDKey="code"
           scale={this.state.scale}
           colorRange={["#ca0004", "#f1e8e8"]}
+          width={1000}
           />
         <Dropdown
           selected={this.state.weightKey}

--- a/examples/example_world.jsx
+++ b/examples/example_world.jsx
@@ -335,6 +335,7 @@ class ExampleApp extends React.Component {
           IDKey="code"
           scale={this.state.scale}
           colorRange={["#f17e33", "#fdf4ee"]}
+          width={900}
           />
         <Dropdown
           selected={this.state.weightKey}

--- a/src/Region.jsx
+++ b/src/Region.jsx
@@ -12,6 +12,17 @@ class Region extends React.Component {
       this.IDList.push(shortId)
       this.IDDict[shortId] = area.title
     }
+    this.state = {
+      height: 0,
+      scale: 1
+    }
+  }
+
+  componentDidMount() {
+    let bbox = this.svgMap.getBBox();
+    let height = bbox.height;
+    let scale = this.props.width/bbox.width;
+    this.setState({ height : height, scale: scale });
   }
 
   getLegend(colors){
@@ -39,20 +50,6 @@ class Region extends React.Component {
   }
 
   render () {
-
-    let xScale = 1
-    let yScale = 1
-    if (this.props.width && this.props.height) {
-      xScale = this.props.width / 650
-      yScale = this.props.height / 725
-    } else if (this.props.width) {
-      xScale = this.props.width / 650
-      yScale = xScale
-    } else if (this.props.height) {
-      yScale = this.props.height / 725
-      xScale = yScale
-    }
-
     let colors = new Coloring(this.IDList, this.props.IDKey, this.props.weightKey, this.props.scale, this.props.data, this.props.colorKey, this.props.colorRange, this.props.colorCatgories)
     let mapColors = colors.generate()
     let legend = this.getLegend(colors)
@@ -71,8 +68,12 @@ class Region extends React.Component {
 
     return(
       <div>
-        <svg width={650*xScale} height={725*yScale}>
-          <g transform={`scale(${xScale} ${yScale})`}>
+        <svg
+          ref={(node) => this.svgMap = node}
+          width={this.props.width}
+          height={this.state.height * this.state.scale}
+        >
+          <g transform={`scale(${this.state.scale})`}>
             {paths}
             {legend}
           </g>

--- a/src/map.jsx
+++ b/src/map.jsx
@@ -70,7 +70,7 @@ class Map extends React.Component {
     let data =  this.extractValues()
 
     let map = <Region
-      paths={this.props.paths} width={this.props.width} height={this.props.height}
+      paths={this.props.paths} width={this.props.width}
       data={data} IDKey={this.props.IDKey} weightKey={this.props.weightKey}
       scale={this.props.scale} colorKey={this.props.colorKey}
       colorRange={this.props.colorRange} colorCatgories={this.props.colorCatgories}
@@ -100,6 +100,7 @@ Map.defaultProps = {
   weightKey: "weight",
   colorRange: ["#000000", "#e8e8e8"],
   scale: "lin",
+  width: 650,
   tooltip: true
   // initialAnimation: true,
 }
@@ -113,6 +114,7 @@ Map.propTypes = {
   colorRange: PropTypes.array,
   colorCatgories: PropTypes.string,
   scale: PropTypes.string,
+  width: PropTypes.number,
   tooltip: PropTypes.bool,
   tooltipColor: PropTypes.string,
   tooltipContents: PropTypes.func


### PR DESCRIPTION
- Map svg is automatically scaled to fit the 'width'
- Removed props: 'height', 'xScale', 'yScale'
- Changed 'width' of US and World examples.

'width' unspecified (default width: 650)
![screen shot 2017-10-29 at 1 22 50 pm](https://user-images.githubusercontent.com/25045998/32146384-f9c95738-bcac-11e7-997b-02ed67717355.png)

'width' = 1000
![screen shot 2017-10-29 at 1 28 57 pm](https://user-images.githubusercontent.com/25045998/32146391-26c41f2a-bcad-11e7-80f7-187f9e655e06.png)

#11 (also #9)

@sanjaypojo @AlmahaAlmalki 
