### PR TITLE
Props for paths keys

### DIFF
--- a/src/Region.jsx
+++ b/src/Region.jsx
@@ -6,10 +6,8 @@ class Region extends React.Component {
   constructor(props) {
     super(props)
     this.IDList = []
-    this.IDDict = {}
     for (let area of this.props.paths) {
-      this.IDList.push(area.id)
-      this.IDDict[area.id] = area.title
+      this.IDList.push(area[this.props.pathIDKey])
     }
     this.state = {
       height: 0,
@@ -56,9 +54,11 @@ class Region extends React.Component {
     let paths = []
     for (let i = 0; i < this.props.paths.length; i++) {
       let area = this.props.paths[i]
+      let id = area[this.props.pathIDKey]
+      let title = area[this.props.pathTitleKey]
       paths.push(
-        <path key={area.id} id={area.id} title={area.title} fill={mapColors[area.id].color}
-          onMouseOver={this.props.activateTooltip.bind(this, mapColors[area.id].raw, this.IDDict[area.id])}
+        <path key={id} id={id} title={title} fill={mapColors[id].color}
+          onMouseOver={this.props.activateTooltip.bind(this, mapColors[id].raw, title)}
           onMouseOut={this.props.deactivateTooltip.bind(this)}
           d={area.d} />
       )

--- a/src/map.jsx
+++ b/src/map.jsx
@@ -68,6 +68,7 @@ class Map extends React.Component {
 
     let map = <Region
       paths={this.props.paths} width={this.props.width}
+      pathIDKey={this.props.pathIDKey} pathTitleKey={this.props.pathTitleKey}
       data={data} IDKey={this.props.IDKey} weightKey={this.props.weightKey}
       scale={this.props.scale} colorKey={this.props.colorKey}
       colorRange={this.props.colorRange} colorCatgories={this.props.colorCatgories}
@@ -94,6 +95,8 @@ class Map extends React.Component {
 Map.defaultProps = {
   IDKey: "ID",
   weightKey: "weight",
+  pathIDKey: "id",
+  pathTitleKey: "title",
   colorRange: ["#000000", "#e8e8e8"],
   scale: "lin",
   width: 650,
@@ -106,6 +109,8 @@ Map.propTypes = {
   paths: PropTypes.arrayOf(PropTypes.object).isRequired,
   IDKey: PropTypes.string,
   weightKey: PropTypes.string,
+  pathIDKey: PropTypes.string,
+  pathTitleKey: PropTypes.string,
   colorKey: PropTypes.string,
   colorRange: PropTypes.array,
   colorCatgories: PropTypes.string,


### PR DESCRIPTION
Added new props to Map:
'pathIDKey': String, defaults to "id". Key for the area IDs of SVG paths.
'pathTitleKey': String, defaults to "title". Key for the area titles of SVG paths.

#17 @sanjaypojo @AlmahaAlmalki 