### PR TITLE
Zooming on map (zoomIDKey, zoomScale)

### DIFF
--- a/src/Region.jsx
+++ b/src/Region.jsx
@@ -12,19 +12,22 @@ class Region extends React.Component {
     this.state = {
       initialHeight: 0,
       initialWidth: 0,
+      currentHeight: 0,
       scale: 1
     }
   }
 
   componentDidMount() {
     let bbox = this.svgMap.getBBox()
-    let height = bbox.height
-    let width = bbox.width
-    let scale = this.props.width/width
+    let initialHeight = bbox.height
+    let initialWidth = bbox.width
+    let scale = this.props.width/initialWidth
+    let currentHeight = initialHeight * scale
     if (this.props.zoomScale) {
       scale *= this.props.zoomScale
     }
-    this.setState({ initialHeight : height, initialWidth: width, scale: scale })
+    this.setState({ initialHeight: initialHeight, initialWidth: initialWidth,
+      currentHeight: currentHeight, scale: scale })
   }
 
   // Prop change - Respond if width, zoomIDKey, or zoomScale changes.
@@ -32,10 +35,11 @@ class Region extends React.Component {
     if (prevProps.width !== this.props.width ||
       prevProps.zoomScale !== this.props.zoomScale) {
       let scale = this.props.width/this.state.initialWidth
+      let currentHeight = this.state.initialHeight * scale
       if (this.props.zoomScale) {
         scale *= this.props.zoomScale
       }
-      this.setState({ scale: scale })
+      this.setState({ currentHeight: currentHeight, scale: scale })
     }
   }
 
@@ -86,7 +90,7 @@ class Region extends React.Component {
         <svg
           ref={(node) => this.svgMap = node}
           width={this.props.width}
-          height={this.state.initialHeight * this.state.scale}
+          height={this.state.currentHeight}
         >
           <g transform={`scale(${this.state.scale})`}>
             {paths}

--- a/src/Region.jsx
+++ b/src/Region.jsx
@@ -21,12 +21,20 @@ class Region extends React.Component {
     let height = bbox.height
     let width = bbox.width
     let scale = this.props.width/width
+    if (this.props.zoomScale) {
+      scale *= this.props.zoomScale
+    }
     this.setState({ initialHeight : height, initialWidth: width, scale: scale })
   }
 
+  // Prop change - Respond if width, zoomIDKey, or zoomScale changes.
   componentDidUpdate(prevProps, prevState) {
-    if (prevProps.width !== this.props.width) {
+    if (prevProps.width !== this.props.width ||
+      prevProps.zoomScale !== this.props.zoomScale) {
       let scale = this.props.width/this.state.initialWidth
+      if (this.props.zoomScale) {
+        scale *= this.props.zoomScale
+      }
       this.setState({ scale: scale })
     }
   }

--- a/src/map.jsx
+++ b/src/map.jsx
@@ -68,6 +68,7 @@ class Map extends React.Component {
 
     let map = <Region
       paths={this.props.paths} width={this.props.width}
+      zoomIDKey={this.props.zoomIDKey} zoomScale={this.props.zoomScale}
       pathIDKey={this.props.pathIDKey} pathTitleKey={this.props.pathTitleKey}
       data={data} IDKey={this.props.IDKey} weightKey={this.props.weightKey}
       scale={this.props.scale} colorKey={this.props.colorKey}
@@ -116,6 +117,8 @@ Map.propTypes = {
   colorCatgories: PropTypes.string,
   scale: PropTypes.string,
   width: PropTypes.number,
+  zoomIDKey: PropTypes.string,
+  zoomScale: PropTypes.number,
   tooltip: PropTypes.bool,
   tooltipColor: PropTypes.string,
   tooltipContents: PropTypes.func


### PR DESCRIPTION
Two new optional Map props for zooming:
"zoomIDKey" (string): ID of the area you're centering on when zooming.
"zoomScale" (number): Scale by which you're zooming.

Behaviors:
- "zoomIDKey" and "zoomScale" are both unspecified: No zooming. Automatically scale to fit the width.
- "zoomIDKey" is specified, but "zoomScale" is unspecified: Zoom centering on the ID'd area with zoom scale of 1.
- "zoomIDKey" is unspecified, but "zoomScale" is specified: Zoom by zoomScale while keeping the top-left corner of map fixed. (Standard SVG scaling) The same behavior applies if zoomIDKey is invalid.
- "zoomIDKey" and "zoomScale" are both specified: Zoom by zoomScale while centering the map on the ID'd area.

Examples:
Default ("zoomIDKey" and "zoomScale" unspecified)
![default](https://user-images.githubusercontent.com/25045998/32641570-b6406594-c59c-11e7-8369-b9e3f8c9b0f6.png)
"zoomIDKey": "US-CA", "zoomScale": unspecified
![zoomid_ca_zoomscale_1](https://user-images.githubusercontent.com/25045998/32641575-bc2a5d02-c59c-11e7-97ed-ef85c58c9e04.png)
"zoomIDKey": unspecified, "zoomScale": 2.5
![zoomscale_2 5_zoomid_unspec](https://user-images.githubusercontent.com/25045998/32641576-bd868e96-c59c-11e7-9cc9-857bd98436d2.png)
"zoomIDKey": "US-CA", "zoomScale": 3
![zoomid_ca_zoomscale_3](https://user-images.githubusercontent.com/25045998/32641573-b9db1ae6-c59c-11e7-9054-097d94832069.png)
"zoomIDKey": "US-MA", "zoomScale": 5
![zoomid_ma_zoomscale_5](https://user-images.githubusercontent.com/25045998/32641578-bebb9fa4-c59c-11e7-9b8e-fbb57a131356.png)

#18 @AlmahaAlmalki @sanjaypojo 
