### PR TITLE
Humanized legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint": "^3.16.1",
     "eslint-plugin-react": "^6.10.0",
     "express": "^4.15.3",
+    "humanize-plus": "^1.8.2",
     "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/src/Region.jsx
+++ b/src/Region.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Coloring from "./coloring.jsx"
+import Humanize from "humanize-plus"
 
 class Region extends React.Component {
 
@@ -79,13 +80,17 @@ class Region extends React.Component {
         <rect key={"rect" + i} x={i*40} y={8} height={20} width={40} fill={colors.colorGradient[i*10].color}/>
       )
       if (i%2 === 0) {
+        let value = parseFloat(colors.colorGradient[i*10].weight.toFixed(2))
+        let printValue = this.humanizeValue(value)
         legend.push(
-          <text key={"label" + i} x={i*40} y={0} textAnchor="middle">{parseFloat(colors.colorGradient[i*10].weight.toFixed(2))}</text>
+          <text key={"label" + i} x={i*40} y={0} textAnchor="middle">{printValue}</text>
         )
       }
     }
+    let value = parseFloat(colors.colorGradient[99].weight.toFixed(2))
+    let printValue = this.humanizeValue(value)
     legend.push(
-      <text key={"endLabel"} x={400} y={0} textAnchor="middle">{parseFloat(colors.colorGradient[99].weight.toFixed(2))}</text>
+      <text key={"endLabel"} x={400} y={0} textAnchor="middle">{printValue}</text>
     )
 
     return (
@@ -93,6 +98,20 @@ class Region extends React.Component {
         {legend}
       </g>
     )
+  }
+
+  humanizeValue(value) {
+    if (value < 1 && value > -1){
+      if (this.props.scale == "lin") {
+        return +value.toFixed(3)
+      } else if (this.props.scale == "log") {
+        return +value.toFixed(5)
+      }
+    } else if (value < 1000 && value > -1000){
+      return +value.toFixed(1)
+    } else {
+      return Humanize.compactInteger(value, 1)
+    }
   }
 
   render () {


### PR DESCRIPTION
Humanizing the legend in the same manner to replot-core axes (https://github.com/MacroConnections/replot-core/blob/master/src/Axis.jsx)

Before:
![screen shot 2017-11-13 at 2 29 20 pm](https://user-images.githubusercontent.com/25045998/32744926-31406be2-c87f-11e7-8e88-3de94b0f9d44.png)
![screen shot 2017-11-13 at 2 29 00 pm](https://user-images.githubusercontent.com/25045998/32744931-32be9732-c87f-11e7-8e97-1f3b369da761.png)
![screen shot 2017-11-13 at 2 28 50 pm](https://user-images.githubusercontent.com/25045998/32744935-33b87356-c87f-11e7-98e4-1fc716a08421.png)
![screen shot 2017-11-13 at 2 28 42 pm](https://user-images.githubusercontent.com/25045998/32744939-3548ca04-c87f-11e7-9cae-ac7dc69397a5.png)

After:
![screen shot 2017-11-13 at 2 27 16 pm](https://user-images.githubusercontent.com/25045998/32744941-381be84c-c87f-11e7-9ce7-50ab021e9ef6.png)
![screen shot 2017-11-13 at 2 27 33 pm](https://user-images.githubusercontent.com/25045998/32744948-3a78a620-c87f-11e7-97fd-c919c424917b.png)
![screen shot 2017-11-13 at 2 27 28 pm](https://user-images.githubusercontent.com/25045998/32744950-3b8afa22-c87f-11e7-9afd-55ded76e38e1.png)
![screen shot 2017-11-13 at 2 27 38 pm](https://user-images.githubusercontent.com/25045998/32744952-3c7b47b6-c87f-11e7-843e-ff9f55135b8f.png)

#12 @AlmahaAlmalki @sanjaypojo 

Also should we give users an option to turn on/off humanized legend? Or should we always humanize it for consistency?