### PR TITLE
Fixed size and position for the legend

### DIFF
--- a/src/Region.jsx
+++ b/src/Region.jsx
@@ -73,19 +73,19 @@ class Region extends React.Component {
   }
 
   getLegend(colors){
-    let HEIGHT = 15
-    let WIDTH = 30
-    let FONT_SIZE = 14
-    let FONT_HEIGHT = 6
-    let PADDING = 20
-    let BACKGROUND = colors.isBackgroundDark() ? "#000000" : "#ffffff"
-    let TEXT_COLOR = colors.isBackgroundDark() ? "#ffffff" : "#000000"
+    const HEIGHT = 15
+    const WIDTH = 30
+    const FONT_SIZE = 14
+    const FONT_HEIGHT = 6
+    const PADDING = 20
+    let background = colors.isBackgroundDark() ? "#000000" : "#ffffff"
+    let text_color = colors.isBackgroundDark() ? "#ffffff" : "#000000"
 
     let legend = []
     legend.push(
       <rect key="background" x={-PADDING} y={-PADDING}
         height={FONT_HEIGHT+HEIGHT+PADDING*1.5} width={WIDTH*10+PADDING*2}
-        fill={BACKGROUND} fillOpacity="0.5"/>
+        fill={background} fillOpacity="0.5"/>
     )
 
     for (let i = 0; i < 10; i++) {
@@ -96,14 +96,14 @@ class Region extends React.Component {
         let value = parseFloat(colors.colorGradient[i*10].weight.toFixed(2))
         let printValue = this.humanizeValue(value)
         legend.push(
-          <text key={"label" + i} x={i*WIDTH} y={0} fontSize={FONT_SIZE} fill={TEXT_COLOR} textAnchor="middle">{printValue}</text>
+          <text key={"label" + i} x={i*WIDTH} y={0} fontSize={FONT_SIZE} fill={text_color} textAnchor="middle">{printValue}</text>
         )
       }
     }
     let value = parseFloat(colors.colorGradient[99].weight.toFixed(2))
     let printValue = this.humanizeValue(value)
     legend.push(
-      <text key={"endLabel"} x={10*WIDTH} y={0} fontSize={FONT_SIZE} fill={TEXT_COLOR} textAnchor="middle">{printValue}</text>
+      <text key={"endLabel"} x={10*WIDTH} y={0} fontSize={FONT_SIZE} fill={text_color} textAnchor="middle">{printValue}</text>
     )
 
     return legend

--- a/src/Region.jsx
+++ b/src/Region.jsx
@@ -73,24 +73,37 @@ class Region extends React.Component {
   }
 
   getLegend(colors){
+    let HEIGHT = 15
+    let WIDTH = 30
+    let FONT_SIZE = 14
+    let FONT_HEIGHT = 6
+    let PADDING = 20
+    let BACKGROUND = "#ffffff"
+    let TEXT_COLOR = "#000000"
+
     let legend = []
+    legend.push(
+      <rect key="background" x={-PADDING} y={-PADDING}
+        height={FONT_HEIGHT+HEIGHT+PADDING*1.5} width={WIDTH*10+PADDING*2}
+        fill={BACKGROUND} fillOpacity="0.5"/>
+    )
 
     for (let i = 0; i < 10; i++) {
       legend.push(
-        <rect key={"rect" + i} x={i*40} y={8} height={20} width={40} fill={colors.colorGradient[i*10].color}/>
+        <rect key={"rect" + i} x={i*WIDTH} y={FONT_HEIGHT} height={HEIGHT} width={WIDTH} fill={colors.colorGradient[i*10].color}/>
       )
       if (i%2 === 0) {
         let value = parseFloat(colors.colorGradient[i*10].weight.toFixed(2))
         let printValue = this.humanizeValue(value)
         legend.push(
-          <text key={"label" + i} x={i*40} y={0} textAnchor="middle">{printValue}</text>
+          <text key={"label" + i} x={i*WIDTH} y={0} fontSize={FONT_SIZE} fill={TEXT_COLOR} textAnchor="middle">{printValue}</text>
         )
       }
     }
     let value = parseFloat(colors.colorGradient[99].weight.toFixed(2))
     let printValue = this.humanizeValue(value)
     legend.push(
-      <text key={"endLabel"} x={400} y={0} textAnchor="middle">{printValue}</text>
+      <text key={"endLabel"} x={10*WIDTH} y={0} fontSize={FONT_SIZE} fill={TEXT_COLOR} textAnchor="middle">{printValue}</text>
     )
 
     return legend

--- a/src/Region.jsx
+++ b/src/Region.jsx
@@ -78,8 +78,8 @@ class Region extends React.Component {
     let FONT_SIZE = 14
     let FONT_HEIGHT = 6
     let PADDING = 20
-    let BACKGROUND = "#ffffff"
-    let TEXT_COLOR = "#000000"
+    let BACKGROUND = colors.isBackgroundDark() ? "#000000" : "#ffffff"
+    let TEXT_COLOR = colors.isBackgroundDark() ? "#ffffff" : "#000000"
 
     let legend = []
     legend.push(

--- a/src/Region.jsx
+++ b/src/Region.jsx
@@ -93,11 +93,7 @@ class Region extends React.Component {
       <text key={"endLabel"} x={400} y={0} textAnchor="middle">{printValue}</text>
     )
 
-    return (
-      <g transform="translate(30, 675)">
-        {legend}
-      </g>
-    )
+    return legend
   }
 
   humanizeValue(value) {
@@ -144,6 +140,8 @@ class Region extends React.Component {
           <g transform={`translate(${this.state.translateX},${this.state.translateY}),
             scale(${this.state.scale})`}>
             {paths}
+          </g>
+          <g transform={`translate(${30},${this.state.currentHeight-50})`}>
             {legend}
           </g>
         </svg>

--- a/src/coloring.jsx
+++ b/src/coloring.jsx
@@ -151,6 +151,18 @@ class Coloring {
 
     return idToColor
   }
+
+  colorToDarkness(hex) {
+    let color = this.convertToRGB(hex)
+    let darkness = 1 - (0.299 * color[0] + 0.587 * color[1] + 0.114 * color[2])/255
+    return darkness
+  }
+
+  isBackgroundDark() {
+    let colorA = this.colorToDarkness(this.colorRange[0])
+    let colorB = this.colorToDarkness(this.colorRange[1])
+    return Math.min(colorA, colorB) < 0.2 && Math.max(colorA, colorB) < 0.8
+  }
 }
 
 export default Coloring


### PR DESCRIPTION
Fixed the legend so it no longer gets scaled/translated with the map when we're scaling on the map. 

![screen shot 2017-11-16 at 5 40 30 pm](https://user-images.githubusercontent.com/25045998/32920011-bb6c6208-caf5-11e7-9f81-2d5e43999313.png)
![screen shot 2017-11-16 at 5 40 42 pm](https://user-images.githubusercontent.com/25045998/32920012-bc15c208-caf5-11e7-9160-f8ff5f9978a2.png)

@AlmahaAlmalki @sanjaypojo #12 

Also my other concern with the current legend is, the legend overlaps the map. Luckily the legend ends up on the emptier part of the map right now, so it looks pretty nice, but if the legend ends up on some region, might be hard to see the legend? (Especially if the legend color happens to be the same as that region's color...!)

Two solutions I'm thinking of is to either move it outside and below the map or add white background to the legend. Let me know what you think!